### PR TITLE
rsync makes files and dirs readable on target

### DIFF
--- a/zeek_log_transport.sh
+++ b/zeek_log_transport.sh
@@ -248,7 +248,7 @@ if  [ ${#send_candidates} -eq 0 ]; then
 
 fi
 status "Transferring files to $aih_location"
-flock -xn "$HOME/rsync_log_transport.lck" timeout --kill-after=60 7080 $nice_me rsync $rsyncparams -avR -e "ssh $extra_ssh_params" $send_candidates "$aih_location:${remote_top_dir}/" --delay-updates
+flock -xn "$HOME/rsync_log_transport.lck" timeout --kill-after=60 7080 $nice_me rsync $rsyncparams -avR -e "ssh $extra_ssh_params" $send_candidates "$aih_location:${remote_top_dir}/" --delay-updates --chmod=Do+rx,Fo+r
 retval=$?
 if [ "$retval" == "1" ]; then
 	status "Unable to obtain lock and run a new copy of rsync as the previous rsync appears to still be running."


### PR DESCRIPTION
As part of transferring files across to AC-Hunter, rsync now forces file and directory permissions so they'll be readable by all users.  (This was put in place because apparently SecurityOnion does not make the files other-readable, meaning that the rita docker process can't get to them or read them.)