### PR TITLE
Default to zeek name rather than bro

### DIFF
--- a/zeek_log_transport.sh
+++ b/zeek_log_transport.sh
@@ -218,10 +218,8 @@ if [ -z "$local_tld" ]; then
 	fi
 fi
 
-ids_name=''
-if [[ $local_tld == *"zeek"* ]]; then
-	ids_name='zeek'
-else
+ids_name='zeek'
+if [[ $local_tld == *"bro"* ]]; then
 	ids_name='bro'
 fi
 


### PR DESCRIPTION
Previously, if the local file path had "zeek" in the name we would send logs to the remote server in the `/opt/zeek/remotelogs` directory, otherwise we'd send to `/opt/bro/remotelogs`. Current versions of AI-Hunter use `/opt/zeek/remotelogs` by default and if the local directory didn't have `zeek` in the name it would fail to transfer.

This change switches the default so that it uses `/opt/zeek/remotelogs` by default and only changes to using `/opt/bro/remotelogs` if the local directory has `bro` in the name. This helps cover backwards compatibility with older versions of AI-Hunter.