### PR TITLE
Transfer capture_loss, notice, and stats logs

### DIFF
--- a/zeek_log_transport.sh
+++ b/zeek_log_transport.sh
@@ -238,7 +238,7 @@ status "Preparing remote directories"
 ssh $extra_ssh_params "$aih_location" "mkdir -p ${remote_top_dir}/$today/ ${remote_top_dir}/$yesterday/ ${remote_top_dir}/$twoda/ ${remote_top_dir}/$threeda/ ${remote_top_dir}/current/"
 
 cd "$local_tld" || fail "Unable to change to $local_tld"
-send_candidates=`find . -type f -mtime -3 -iname '*.gz' | egrep '(conn|dns|http|ssl|x509|known_certs)' | sort -u`
+send_candidates=`find . -type f -mtime -3 -iname '*.gz' | egrep '(conn|dns|http|ssl|x509|known_certs|capture_loss|notice|stats)' | sort -u`
 if  [ ${#send_candidates} -eq 0 ]; then
 	echo
 	printf "WARNING: No logs found, if your log directory is not $local_tld please use the flag: --localdir [bro_zeek_log_directory]"


### PR DESCRIPTION
These logs are extremely useful for troubleshooting capture issues.

We don't always have access to the underlying Zeek sensor and still need to be able to detect and give recommendations about capture problems. These logs are useful for this purpose.

https://github.com/activecm/zeek-log-transport/issues/3#issuecomment-844560212